### PR TITLE
fix!: Use `i32` for UTC offset.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strptime"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["Luke Sneeringer <luke@sneeringer.com>"]
 description = "Date & time parsing without date library dependencies."

--- a/src/models.rs
+++ b/src/models.rs
@@ -48,7 +48,7 @@ pub struct RawTime {
   pub(crate) minute: u8,
   pub(crate) second: u8,
   pub(crate) nanosecond: u64,
-  pub(crate) utc_offset: Option<i64>,
+  pub(crate) utc_offset: Option<i32>,
 }
 
 impl RawTime {
@@ -78,7 +78,7 @@ impl RawTime {
 
   /// The UTC offset, in seconds, if one was parsed.
   #[inline]
-  pub const fn utc_offset(&self) -> Option<i64> {
+  pub const fn utc_offset(&self) -> Option<i32> {
     self.utc_offset
   }
 }
@@ -158,7 +158,7 @@ set_time!(
 );
 
 impl RawDateTime {
-  pub(crate) fn set_utc_offset(&mut self, hhmm: i64) {
+  pub(crate) fn set_utc_offset(&mut self, hhmm: i32) {
     let hours = hhmm / 100;
     let minutes = hhmm % 100;
     let time = self.time.get_or_insert_with(RawTime::default);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,7 @@ impl<'a> OnceParser<'a> {
               _ => answer.set_nanosecond(input.parse_int::<u64>(9, Some('0'))?),
             },
             // Time Zone
-            'z' => answer.set_utc_offset(input.parse_int::<i64>(5, None)?),
+            'z' => answer.set_utc_offset(input.parse_int::<i32>(5, None)?),
             // Padding change modifiers.
             '-' | '0' | ' ' => {
               padding = Some(ch);


### PR DESCRIPTION
This will make it match the underlying `tz` and `tzdb` crates, and 1.1.0 has only been released for 38 minutes, and has 2 downloads (both of which are me), so nobody will be inconvenienced by the fix.